### PR TITLE
Add toggles for overriding audio properties

### DIFF
--- a/Packages/com.varneon.vudon.simple-player-settings/Runtime/Udon Programs/SimplePlayerSettings.asset
+++ b/Packages/com.varneon.vudon.simple-player-settings/Runtime/Udon Programs/SimplePlayerSettings.asset
@@ -44,7 +44,7 @@ MonoBehaviour:
       Data: 
     - Name: 
       Entry: 12
-      Data: 20
+      Data: 22
     - Name: 
       Entry: 7
       Data: 
@@ -394,10 +394,79 @@ MonoBehaviour:
       Data: 
     - Name: $k
       Entry: 1
-      Data: voiceGain
+      Data: overridePlayerVoices
     - Name: $v
       Entry: 7
       Data: 23|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
+    - Name: <Name>k__BackingField
+      Entry: 1
+      Data: overridePlayerVoices
+    - Name: <UserType>k__BackingField
+      Entry: 7
+      Data: 24|System.RuntimeType, mscorlib
+    - Name: 
+      Entry: 1
+      Data: System.Boolean, mscorlib
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: <SystemType>k__BackingField
+      Entry: 9
+      Data: 24
+    - Name: <SyncMode>k__BackingField
+      Entry: 7
+      Data: System.Nullable`1[[UdonSharp.UdonSyncMode, UdonSharp.Runtime]], mscorlib
+    - Name: 
+      Entry: 6
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: <IsSerialized>k__BackingField
+      Entry: 5
+      Data: true
+    - Name: _fieldAttributes
+      Entry: 7
+      Data: 25|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
+    - Name: 
+      Entry: 12
+      Data: 2
+    - Name: 
+      Entry: 7
+      Data: 26|UnityEngine.SerializeField, UnityEngine.CoreModule
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: 27|UnityEngine.TooltipAttribute, UnityEngine.CoreModule
+    - Name: tooltip
+      Entry: 1
+      Data: Should Player Voices be overridden with the properties below
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 13
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: 
+    - Name: $k
+      Entry: 1
+      Data: voiceGain
+    - Name: $v
+      Entry: 7
+      Data: 28|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
     - Name: <Name>k__BackingField
       Entry: 1
       Data: voiceGain
@@ -421,31 +490,19 @@ MonoBehaviour:
       Data: true
     - Name: _fieldAttributes
       Entry: 7
-      Data: 24|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
+      Data: 29|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
     - Name: 
       Entry: 12
-      Data: 3
+      Data: 2
     - Name: 
       Entry: 7
-      Data: 25|UnityEngine.SerializeField, UnityEngine.CoreModule
+      Data: 30|UnityEngine.SerializeField, UnityEngine.CoreModule
     - Name: 
       Entry: 8
       Data: 
     - Name: 
       Entry: 7
-      Data: 26|UnityEngine.RangeAttribute, UnityEngine.CoreModule
-    - Name: min
-      Entry: 4
-      Data: 0
-    - Name: max
-      Entry: 4
-      Data: 24
-    - Name: 
-      Entry: 8
-      Data: 
-    - Name: 
-      Entry: 7
-      Data: 27|UnityEngine.TooltipAttribute, UnityEngine.CoreModule
+      Data: 31|UnityEngine.TooltipAttribute, UnityEngine.CoreModule
     - Name: tooltip
       Entry: 1
       Data: 'In Decibels, Range 0 - 24
@@ -476,7 +533,7 @@ MonoBehaviour:
       Data: voiceDistanceNear
     - Name: $v
       Entry: 7
-      Data: 28|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
+      Data: 32|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
     - Name: <Name>k__BackingField
       Entry: 1
       Data: voiceDistanceNear
@@ -500,31 +557,19 @@ MonoBehaviour:
       Data: true
     - Name: _fieldAttributes
       Entry: 7
-      Data: 29|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
+      Data: 33|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
     - Name: 
       Entry: 12
-      Data: 3
+      Data: 2
     - Name: 
       Entry: 7
-      Data: 30|UnityEngine.SerializeField, UnityEngine.CoreModule
+      Data: 34|UnityEngine.SerializeField, UnityEngine.CoreModule
     - Name: 
       Entry: 8
       Data: 
     - Name: 
       Entry: 7
-      Data: 31|UnityEngine.RangeAttribute, UnityEngine.CoreModule
-    - Name: min
-      Entry: 4
-      Data: 0
-    - Name: max
-      Entry: 4
-      Data: 1000000
-    - Name: 
-      Entry: 8
-      Data: 
-    - Name: 
-      Entry: 7
-      Data: 32|UnityEngine.TooltipAttribute, UnityEngine.CoreModule
+      Data: 35|UnityEngine.TooltipAttribute, UnityEngine.CoreModule
     - Name: tooltip
       Entry: 1
       Data: 'In Meters, Range 0 - 1,000,000
@@ -556,7 +601,7 @@ MonoBehaviour:
       Data: voiceDistanceFar
     - Name: $v
       Entry: 7
-      Data: 33|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
+      Data: 36|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
     - Name: <Name>k__BackingField
       Entry: 1
       Data: voiceDistanceFar
@@ -580,31 +625,19 @@ MonoBehaviour:
       Data: true
     - Name: _fieldAttributes
       Entry: 7
-      Data: 34|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
+      Data: 37|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
     - Name: 
       Entry: 12
-      Data: 3
+      Data: 2
     - Name: 
       Entry: 7
-      Data: 35|UnityEngine.SerializeField, UnityEngine.CoreModule
+      Data: 38|UnityEngine.SerializeField, UnityEngine.CoreModule
     - Name: 
       Entry: 8
       Data: 
     - Name: 
       Entry: 7
-      Data: 36|UnityEngine.RangeAttribute, UnityEngine.CoreModule
-    - Name: min
-      Entry: 4
-      Data: 0
-    - Name: max
-      Entry: 4
-      Data: 1000000
-    - Name: 
-      Entry: 8
-      Data: 
-    - Name: 
-      Entry: 7
-      Data: 37|UnityEngine.TooltipAttribute, UnityEngine.CoreModule
+      Data: 39|UnityEngine.TooltipAttribute, UnityEngine.CoreModule
     - Name: tooltip
       Entry: 1
       Data: 'In Meters, Range is 0 - 1,000,000
@@ -636,7 +669,7 @@ MonoBehaviour:
       Data: voiceVolumetricRadius
     - Name: $v
       Entry: 7
-      Data: 38|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
+      Data: 40|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
     - Name: <Name>k__BackingField
       Entry: 1
       Data: voiceVolumetricRadius
@@ -660,31 +693,19 @@ MonoBehaviour:
       Data: true
     - Name: _fieldAttributes
       Entry: 7
-      Data: 39|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
+      Data: 41|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
     - Name: 
       Entry: 12
-      Data: 3
+      Data: 2
     - Name: 
       Entry: 7
-      Data: 40|UnityEngine.SerializeField, UnityEngine.CoreModule
+      Data: 42|UnityEngine.SerializeField, UnityEngine.CoreModule
     - Name: 
       Entry: 8
       Data: 
     - Name: 
       Entry: 7
-      Data: 41|UnityEngine.RangeAttribute, UnityEngine.CoreModule
-    - Name: min
-      Entry: 4
-      Data: 0
-    - Name: max
-      Entry: 4
-      Data: 1000
-    - Name: 
-      Entry: 8
-      Data: 
-    - Name: 
-      Entry: 7
-      Data: 42|UnityEngine.TooltipAttribute, UnityEngine.CoreModule
+      Data: 43|UnityEngine.TooltipAttribute, UnityEngine.CoreModule
     - Name: tooltip
       Entry: 1
       Data: 'In Meters, Range is 0 - 1,000
@@ -724,22 +745,16 @@ MonoBehaviour:
       Data: voiceLowpass
     - Name: $v
       Entry: 7
-      Data: 43|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
+      Data: 44|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
     - Name: <Name>k__BackingField
       Entry: 1
       Data: voiceLowpass
     - Name: <UserType>k__BackingField
-      Entry: 7
-      Data: 44|System.RuntimeType, mscorlib
-    - Name: 
-      Entry: 1
-      Data: System.Boolean, mscorlib
-    - Name: 
-      Entry: 8
-      Data: 
+      Entry: 9
+      Data: 24
     - Name: <SystemType>k__BackingField
       Entry: 9
-      Data: 44
+      Data: 24
     - Name: <SyncMode>k__BackingField
       Entry: 7
       Data: System.Nullable`1[[UdonSharp.UdonSyncMode, UdonSharp.Runtime]], mscorlib
@@ -793,10 +808,73 @@ MonoBehaviour:
       Data: 
     - Name: $k
       Entry: 1
-      Data: avatarAudioGain
+      Data: overrideAvatarAudio
     - Name: $v
       Entry: 7
       Data: 48|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
+    - Name: <Name>k__BackingField
+      Entry: 1
+      Data: overrideAvatarAudio
+    - Name: <UserType>k__BackingField
+      Entry: 9
+      Data: 24
+    - Name: <SystemType>k__BackingField
+      Entry: 9
+      Data: 24
+    - Name: <SyncMode>k__BackingField
+      Entry: 7
+      Data: System.Nullable`1[[UdonSharp.UdonSyncMode, UdonSharp.Runtime]], mscorlib
+    - Name: 
+      Entry: 6
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: <IsSerialized>k__BackingField
+      Entry: 5
+      Data: true
+    - Name: _fieldAttributes
+      Entry: 7
+      Data: 49|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
+    - Name: 
+      Entry: 12
+      Data: 2
+    - Name: 
+      Entry: 7
+      Data: 50|UnityEngine.SerializeField, UnityEngine.CoreModule
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: 51|UnityEngine.TooltipAttribute, UnityEngine.CoreModule
+    - Name: tooltip
+      Entry: 1
+      Data: Should Avatar Audio be overridden with the properties below
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 13
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: 
+    - Name: $k
+      Entry: 1
+      Data: avatarAudioGain
+    - Name: $v
+      Entry: 7
+      Data: 52|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
     - Name: <Name>k__BackingField
       Entry: 1
       Data: avatarAudioGain
@@ -820,31 +898,19 @@ MonoBehaviour:
       Data: true
     - Name: _fieldAttributes
       Entry: 7
-      Data: 49|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
+      Data: 53|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
     - Name: 
       Entry: 12
-      Data: 3
+      Data: 2
     - Name: 
       Entry: 7
-      Data: 50|UnityEngine.SerializeField, UnityEngine.CoreModule
+      Data: 54|UnityEngine.SerializeField, UnityEngine.CoreModule
     - Name: 
       Entry: 8
       Data: 
     - Name: 
       Entry: 7
-      Data: 51|UnityEngine.RangeAttribute, UnityEngine.CoreModule
-    - Name: min
-      Entry: 4
-      Data: 0
-    - Name: max
-      Entry: 4
-      Data: 10
-    - Name: 
-      Entry: 8
-      Data: 
-    - Name: 
-      Entry: 7
-      Data: 52|UnityEngine.TooltipAttribute, UnityEngine.CoreModule
+      Data: 55|UnityEngine.TooltipAttribute, UnityEngine.CoreModule
     - Name: tooltip
       Entry: 1
       Data: 'In Decibels, Range 0-10
@@ -875,7 +941,7 @@ MonoBehaviour:
       Data: avatarAudioNearRadius
     - Name: $v
       Entry: 7
-      Data: 53|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
+      Data: 56|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
     - Name: <Name>k__BackingField
       Entry: 1
       Data: avatarAudioNearRadius
@@ -899,19 +965,19 @@ MonoBehaviour:
       Data: true
     - Name: _fieldAttributes
       Entry: 7
-      Data: 54|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
+      Data: 57|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
     - Name: 
       Entry: 12
       Data: 2
     - Name: 
       Entry: 7
-      Data: 55|UnityEngine.SerializeField, UnityEngine.CoreModule
+      Data: 58|UnityEngine.SerializeField, UnityEngine.CoreModule
     - Name: 
       Entry: 8
       Data: 
     - Name: 
       Entry: 7
-      Data: 56|UnityEngine.TooltipAttribute, UnityEngine.CoreModule
+      Data: 59|UnityEngine.TooltipAttribute, UnityEngine.CoreModule
     - Name: tooltip
       Entry: 1
       Data: 'In Meters, Range is not limited
@@ -945,7 +1011,7 @@ MonoBehaviour:
       Data: avatarAudioFarRadius
     - Name: $v
       Entry: 7
-      Data: 57|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
+      Data: 60|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
     - Name: <Name>k__BackingField
       Entry: 1
       Data: avatarAudioFarRadius
@@ -969,19 +1035,19 @@ MonoBehaviour:
       Data: true
     - Name: _fieldAttributes
       Entry: 7
-      Data: 58|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
+      Data: 61|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
     - Name: 
       Entry: 12
       Data: 2
     - Name: 
       Entry: 7
-      Data: 59|UnityEngine.SerializeField, UnityEngine.CoreModule
+      Data: 62|UnityEngine.SerializeField, UnityEngine.CoreModule
     - Name: 
       Entry: 8
       Data: 
     - Name: 
       Entry: 7
-      Data: 60|UnityEngine.TooltipAttribute, UnityEngine.CoreModule
+      Data: 63|UnityEngine.TooltipAttribute, UnityEngine.CoreModule
     - Name: tooltip
       Entry: 1
       Data: 'In Meters, Range is not limited
@@ -1015,7 +1081,7 @@ MonoBehaviour:
       Data: avatarAudioVolumetricRadius
     - Name: $v
       Entry: 7
-      Data: 61|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
+      Data: 64|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
     - Name: <Name>k__BackingField
       Entry: 1
       Data: avatarAudioVolumetricRadius
@@ -1039,19 +1105,19 @@ MonoBehaviour:
       Data: true
     - Name: _fieldAttributes
       Entry: 7
-      Data: 62|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
+      Data: 65|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
     - Name: 
       Entry: 12
       Data: 2
     - Name: 
       Entry: 7
-      Data: 63|UnityEngine.SerializeField, UnityEngine.CoreModule
+      Data: 66|UnityEngine.SerializeField, UnityEngine.CoreModule
     - Name: 
       Entry: 8
       Data: 
     - Name: 
       Entry: 7
-      Data: 64|UnityEngine.TooltipAttribute, UnityEngine.CoreModule
+      Data: 67|UnityEngine.TooltipAttribute, UnityEngine.CoreModule
     - Name: tooltip
       Entry: 1
       Data: 'In Meters, Range is not limited
@@ -1087,16 +1153,16 @@ MonoBehaviour:
       Data: avatarAudioForceSpatial
     - Name: $v
       Entry: 7
-      Data: 65|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
+      Data: 68|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
     - Name: <Name>k__BackingField
       Entry: 1
       Data: avatarAudioForceSpatial
     - Name: <UserType>k__BackingField
       Entry: 9
-      Data: 44
+      Data: 24
     - Name: <SystemType>k__BackingField
       Entry: 9
-      Data: 44
+      Data: 24
     - Name: <SyncMode>k__BackingField
       Entry: 7
       Data: System.Nullable`1[[UdonSharp.UdonSyncMode, UdonSharp.Runtime]], mscorlib
@@ -1111,19 +1177,19 @@ MonoBehaviour:
       Data: true
     - Name: _fieldAttributes
       Entry: 7
-      Data: 66|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
+      Data: 69|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
     - Name: 
       Entry: 12
       Data: 2
     - Name: 
       Entry: 7
-      Data: 67|UnityEngine.SerializeField, UnityEngine.CoreModule
+      Data: 70|UnityEngine.SerializeField, UnityEngine.CoreModule
     - Name: 
       Entry: 8
       Data: 
     - Name: 
       Entry: 7
-      Data: 68|UnityEngine.TooltipAttribute, UnityEngine.CoreModule
+      Data: 71|UnityEngine.TooltipAttribute, UnityEngine.CoreModule
     - Name: tooltip
       Entry: 1
       Data: If this is on, then Spatialization is enabled for the source, and the
@@ -1151,16 +1217,16 @@ MonoBehaviour:
       Data: avatarAudioCustomCurve
     - Name: $v
       Entry: 7
-      Data: 69|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
+      Data: 72|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
     - Name: <Name>k__BackingField
       Entry: 1
       Data: avatarAudioCustomCurve
     - Name: <UserType>k__BackingField
       Entry: 9
-      Data: 44
+      Data: 24
     - Name: <SystemType>k__BackingField
       Entry: 9
-      Data: 44
+      Data: 24
     - Name: <SyncMode>k__BackingField
       Entry: 7
       Data: System.Nullable`1[[UdonSharp.UdonSyncMode, UdonSharp.Runtime]], mscorlib
@@ -1175,19 +1241,19 @@ MonoBehaviour:
       Data: true
     - Name: _fieldAttributes
       Entry: 7
-      Data: 70|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
+      Data: 73|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
     - Name: 
       Entry: 12
       Data: 2
     - Name: 
       Entry: 7
-      Data: 71|UnityEngine.SerializeField, UnityEngine.CoreModule
+      Data: 74|UnityEngine.SerializeField, UnityEngine.CoreModule
     - Name: 
       Entry: 8
       Data: 
     - Name: 
       Entry: 7
-      Data: 72|UnityEngine.TooltipAttribute, UnityEngine.CoreModule
+      Data: 75|UnityEngine.TooltipAttribute, UnityEngine.CoreModule
     - Name: tooltip
       Entry: 1
       Data: This sets whether the audio source should use a pre-configured custom
@@ -1215,16 +1281,16 @@ MonoBehaviour:
       Data: allowManualAvatarScaling
     - Name: $v
       Entry: 7
-      Data: 73|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
+      Data: 76|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
     - Name: <Name>k__BackingField
       Entry: 1
       Data: allowManualAvatarScaling
     - Name: <UserType>k__BackingField
       Entry: 9
-      Data: 44
+      Data: 24
     - Name: <SystemType>k__BackingField
       Entry: 9
-      Data: 44
+      Data: 24
     - Name: <SyncMode>k__BackingField
       Entry: 7
       Data: System.Nullable`1[[UdonSharp.UdonSyncMode, UdonSharp.Runtime]], mscorlib
@@ -1239,19 +1305,19 @@ MonoBehaviour:
       Data: true
     - Name: _fieldAttributes
       Entry: 7
-      Data: 74|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
+      Data: 77|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
     - Name: 
       Entry: 12
       Data: 2
     - Name: 
       Entry: 7
-      Data: 75|UnityEngine.SerializeField, UnityEngine.CoreModule
+      Data: 78|UnityEngine.SerializeField, UnityEngine.CoreModule
     - Name: 
       Entry: 8
       Data: 
     - Name: 
       Entry: 7
-      Data: 76|UnityEngine.TooltipAttribute, UnityEngine.CoreModule
+      Data: 79|UnityEngine.TooltipAttribute, UnityEngine.CoreModule
     - Name: tooltip
       Entry: 1
       Data: Should players be allowed to manually scale their avatars.
@@ -1278,7 +1344,7 @@ MonoBehaviour:
       Data: minimumHeight
     - Name: $v
       Entry: 7
-      Data: 77|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
+      Data: 80|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
     - Name: <Name>k__BackingField
       Entry: 1
       Data: minimumHeight
@@ -1302,31 +1368,19 @@ MonoBehaviour:
       Data: true
     - Name: _fieldAttributes
       Entry: 7
-      Data: 78|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
+      Data: 81|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
     - Name: 
       Entry: 12
-      Data: 3
+      Data: 2
     - Name: 
       Entry: 7
-      Data: 79|UnityEngine.SerializeField, UnityEngine.CoreModule
+      Data: 82|UnityEngine.SerializeField, UnityEngine.CoreModule
     - Name: 
       Entry: 8
       Data: 
     - Name: 
       Entry: 7
-      Data: 80|UnityEngine.RangeAttribute, UnityEngine.CoreModule
-    - Name: min
-      Entry: 4
-      Data: 0.2
-    - Name: max
-      Entry: 4
-      Data: 5
-    - Name: 
-      Entry: 8
-      Data: 
-    - Name: 
-      Entry: 7
-      Data: 81|UnityEngine.TooltipAttribute, UnityEngine.CoreModule
+      Data: 83|UnityEngine.TooltipAttribute, UnityEngine.CoreModule
     - Name: tooltip
       Entry: 1
       Data: Minimum height in meters that the local player is permitted to scale
@@ -1355,7 +1409,7 @@ MonoBehaviour:
       Data: maximumHeight
     - Name: $v
       Entry: 7
-      Data: 82|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
+      Data: 84|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
     - Name: <Name>k__BackingField
       Entry: 1
       Data: maximumHeight
@@ -1379,31 +1433,19 @@ MonoBehaviour:
       Data: true
     - Name: _fieldAttributes
       Entry: 7
-      Data: 83|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
+      Data: 85|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
     - Name: 
       Entry: 12
-      Data: 3
+      Data: 2
     - Name: 
       Entry: 7
-      Data: 84|UnityEngine.SerializeField, UnityEngine.CoreModule
+      Data: 86|UnityEngine.SerializeField, UnityEngine.CoreModule
     - Name: 
       Entry: 8
       Data: 
     - Name: 
       Entry: 7
-      Data: 85|UnityEngine.RangeAttribute, UnityEngine.CoreModule
-    - Name: min
-      Entry: 4
-      Data: 0.2
-    - Name: max
-      Entry: 4
-      Data: 5
-    - Name: 
-      Entry: 8
-      Data: 
-    - Name: 
-      Entry: 7
-      Data: 86|UnityEngine.TooltipAttribute, UnityEngine.CoreModule
+      Data: 87|UnityEngine.TooltipAttribute, UnityEngine.CoreModule
     - Name: tooltip
       Entry: 1
       Data: Maximum eye height in meters that the local player is permitted to scale
@@ -1432,16 +1474,16 @@ MonoBehaviour:
       Data: alwaysEnforceHeight
     - Name: $v
       Entry: 7
-      Data: 87|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
+      Data: 88|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
     - Name: <Name>k__BackingField
       Entry: 1
       Data: alwaysEnforceHeight
     - Name: <UserType>k__BackingField
       Entry: 9
-      Data: 44
+      Data: 24
     - Name: <SystemType>k__BackingField
       Entry: 9
-      Data: 44
+      Data: 24
     - Name: <SyncMode>k__BackingField
       Entry: 7
       Data: System.Nullable`1[[UdonSharp.UdonSyncMode, UdonSharp.Runtime]], mscorlib
@@ -1456,19 +1498,19 @@ MonoBehaviour:
       Data: true
     - Name: _fieldAttributes
       Entry: 7
-      Data: 88|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
+      Data: 89|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
     - Name: 
       Entry: 12
       Data: 2
     - Name: 
       Entry: 7
-      Data: 89|UnityEngine.SerializeField, UnityEngine.CoreModule
+      Data: 90|UnityEngine.SerializeField, UnityEngine.CoreModule
     - Name: 
       Entry: 8
       Data: 
     - Name: 
       Entry: 7
-      Data: 90|UnityEngine.TooltipAttribute, UnityEngine.CoreModule
+      Data: 91|UnityEngine.TooltipAttribute, UnityEngine.CoreModule
     - Name: tooltip
       Entry: 1
       Data: Ensure that player's height is always within the allowed range when the

--- a/Packages/com.varneon.vudon.simple-player-settings/Runtime/Udon Programs/SimplePlayerSettings.cs
+++ b/Packages/com.varneon.vudon.simple-player-settings/Runtime/Udon Programs/SimplePlayerSettings.cs
@@ -53,11 +53,20 @@ namespace Varneon.VUdon.SimplePlayerSettings
         private float gravityStrength = 1f;
 
         /// <summary>
+        /// <see href="https://creators.vrchat.com/worlds/udon/players/player-audio"/>
+        /// </summary>
+        [SerializeField]
+        [FoldoutHeader("Player Voices")]
+        [Tooltip("Should Player Voices be overridden with the properties below")]
+        [FieldLabel("Override")]
+        private bool overridePlayerVoices = true;
+
+        /// <summary>
         /// <see href="https://creators.vrchat.com/worlds/udon/players/player-audio#set-voice-gain"/>
         /// </summary>
-        [FoldoutHeader("Player Voice")]
         [SerializeField]
-        [Range(0f, 24f)]
+        [FieldDisable(nameof(overridePlayerVoices))]
+        [FieldRange(0f, 24f)]
         [Tooltip("In Decibels, Range 0 - 24\n\nAdd boost to the Player's voice in decibels.")]
         [FieldLabel("Gain")]
         private float voiceGain = 15f;
@@ -66,7 +75,8 @@ namespace Varneon.VUdon.SimplePlayerSettings
         /// <see href="https://creators.vrchat.com/worlds/udon/players/player-audio#set-voice-distance-near"/>
         /// </summary>
         [SerializeField]
-        [Range(0f, 1000000f)]
+        [FieldDisable(nameof(overridePlayerVoices))]
+        [FieldRange(0f, 1000000f)]
         [Tooltip("In Meters, Range 0 - 1,000,000\n\nThe near radius, in meters, where volume begins to fall off. It is strongly recommended to leave the Near value at zero for realism and effective spatialization for user voices.")]
         [FieldLabel("Distance Near")]
         private float voiceDistanceNear = 0f;
@@ -75,7 +85,8 @@ namespace Varneon.VUdon.SimplePlayerSettings
         /// <see href="https://creators.vrchat.com/worlds/udon/players/player-audio#set-voice-distance-far"/>
         /// </summary>
         [SerializeField]
-        [Range(0f, 1000000f)]
+        [FieldDisable(nameof(overridePlayerVoices))]
+        [FieldRange(0f, 1000000f)]
         [Tooltip("In Meters, Range is 0 - 1,000,000\n\nThis sets the end of the range for hearing the user's voice. You can lower this to make another player's voice not travel as far, all the way to 0 to effectively 'mute' the player.")]
         [FieldLabel("Distance Far")]
         private float voiceDistanceFar = 25f;
@@ -84,7 +95,8 @@ namespace Varneon.VUdon.SimplePlayerSettings
         /// <see href="https://creators.vrchat.com/worlds/udon/players/player-audio#set-voice-volumetric-radius"/>
         /// </summary>
         [SerializeField]
-        [Range(0f, 1000f)]
+        [FieldDisable(nameof(overridePlayerVoices))]
+        [FieldRange(0f, 1000f)]
         [Tooltip("In Meters, Range is 0 - 1,000\n\nA player's voice is normally simulated to be a point source, however changing this value allows the source to appear to come from a larger area. This should be used carefully, and is mainly for distant audio sources that need to sound \"large\" as you move past them. Keep this at zero unless you know what you're doing. The value for Volumetric Radius should always be lower than Voice Distance Far.\n\nIf you want a user's voice to sound like it is close no matter how far it is, increase the Voice Distance Near range to a large value.")]
         [FieldLabel("Volumetric Radius")]
         private float voiceVolumetricRadius = 0;
@@ -93,16 +105,26 @@ namespace Varneon.VUdon.SimplePlayerSettings
         /// <see href="https://creators.vrchat.com/worlds/udon/players/player-audio#set-voice-lowpass"/>
         /// </summary>
         [SerializeField]
+        [FieldDisable(nameof(overridePlayerVoices))]
         [Tooltip("When a voice is some distance off, it is passed through a low-pass filter to help with understanding noisy worlds. You can disable this if you want to skip this filter. For example, if you intend for a player to use their voice channel to play a high-quality DJ mix, turning this filter off is advisable.")]
         [FieldLabel("Lowpass")]
         private bool voiceLowpass = true;
 
         /// <summary>
+        /// <see href="https://creators.vrchat.com/worlds/udon/players/player-audio"/>
+        /// </summary>
+        [SerializeField]
+        [FoldoutHeader("Avatar Audio")]
+        [Tooltip("Should Avatar Audio be overridden with the properties below")]
+        [FieldLabel("Override")]
+        private bool overrideAvatarAudio = true;
+
+        /// <summary>
         /// <see href="https://creators.vrchat.com/worlds/udon/players/player-audio#setavataraudiogain"/>
         /// </summary>
-        [FoldoutHeader("Avatar Audio")]
         [SerializeField]
-        [Range(0f, 10f)]
+        [FieldDisable(nameof(overrideAvatarAudio))]
+        [FieldRange(0f, 10f)]
         [Tooltip("In Decibels, Range 0-10\n\nSet the Maximum Gain allowed on Avatar Audio.")]
         [FieldLabel("Gain")]
         private float avatarAudioGain = 10f;
@@ -111,6 +133,7 @@ namespace Varneon.VUdon.SimplePlayerSettings
         /// <see href="https://creators.vrchat.com/worlds/udon/players/player-audio#setavataraudionearradius"/>
         /// </summary>
         [SerializeField]
+        [FieldDisable(nameof(overrideAvatarAudio))]
         [Tooltip("In Meters, Range is not limited\n\nThis sets the maximum start of the range for hearing the avatar's audio. You can lower this to make another player's avatar not travel as far, all the way to 0 to effectively 'mute' the player. Note that this is compared to the audio source's minDistance, and the smaller value is used.")]
         [FieldLabel("Near Radius")]
         private float avatarAudioNearRadius = 40f;
@@ -119,6 +142,7 @@ namespace Varneon.VUdon.SimplePlayerSettings
         /// <see href="https://creators.vrchat.com/worlds/udon/players/player-audio#setavataraudiofarradius"/>
         /// </summary>
         [SerializeField]
+        [FieldDisable(nameof(overrideAvatarAudio))]
         [Tooltip("In Meters, Range is not limited\n\nThis sets the maximum end of the range for hearing the avatar's audio. You can lower this to make another player's avatar not travel as far, all the way to 0 to effectively 'mute' the player. Note that this is compared to the audio source's maxDistance, and the smaller value is used.")]
         [FieldLabel("Far Radius")]
         private float avatarAudioFarRadius = 40f;
@@ -127,6 +151,7 @@ namespace Varneon.VUdon.SimplePlayerSettings
         /// <see href="https://creators.vrchat.com/worlds/udon/players/player-audio#setavataraudiovolumetricradius"/>
         /// </summary>
         [SerializeField]
+        [FieldDisable(nameof(overrideAvatarAudio))]
         [Tooltip("In Meters, Range is not limited\n\nAn avatar's audio source is normally simulated to be a point source, however changing this value allows the source to appear to come from a larger area. This should be used carefully, and is mainly for distant audio sources that need to sound \"large\" as you move past them. Keep this at zero unless you know what you're doing. The value for Volumetric Radius should always be lower than Avatar AUdio Far Radius.")]
         [FieldLabel("Volumetric Radius")]
         private float avatarAudioVolumetricRadius = 0;
@@ -135,6 +160,7 @@ namespace Varneon.VUdon.SimplePlayerSettings
         /// <see href="https://creators.vrchat.com/worlds/udon/players/player-audio#setavataraudioforcespatial"/>
         /// </summary>
         [SerializeField]
+        [FieldDisable(nameof(overrideAvatarAudio))]
         [Tooltip("If this is on, then Spatialization is enabled for the source, and the spatialBlend is set to 1.")]
         [FieldLabel("Force Spatial")]
         private bool avatarAudioForceSpatial = false;
@@ -143,6 +169,7 @@ namespace Varneon.VUdon.SimplePlayerSettings
         /// <see href="https://creators.vrchat.com/worlds/udon/players/player-audio#setavataraudiocustomcurve"/>
         /// </summary>
         [SerializeField]
+        [FieldDisable(nameof(overrideAvatarAudio))]
         [Tooltip("This sets whether the audio source should use a pre-configured custom curve.")]
         [FieldLabel("Custom Curve")]
         private bool avatarAudioCustomCurve = false;
@@ -159,7 +186,7 @@ namespace Varneon.VUdon.SimplePlayerSettings
         /// <see href="https://creators.vrchat.com/worlds/udon/players/player-avatar-scaling#setavatareyeheightminimumbymeters"/>
         /// </summary>
         [SerializeField]
-        [Range(0.2f, 5f)]
+        [FieldRange(0.2f, 5f)]
         [Tooltip("Minimum height in meters that the local player is permitted to scale themselves to in the player-controlled avatar scaling mode. (Must be greater than or equal to 0.2 meters.)")]
         private float minimumHeight = 0.2f;
 
@@ -167,7 +194,7 @@ namespace Varneon.VUdon.SimplePlayerSettings
         /// <see href="https://creators.vrchat.com/worlds/udon/players/player-avatar-scaling#setavatareyeheightmaximumbymeters"/>
         /// </summary>
         [SerializeField]
-        [Range(0.2f, 5f)]
+        [FieldRange(0.2f, 5f)]
         [Tooltip("Maximum eye height in meters that the local player is permitted to scale themselves to in the player-controlled avatar scaling mode. (Must be less or equal to 5 meters.)")]
         private float maximumHeight = 5f;
 
@@ -180,6 +207,7 @@ namespace Varneon.VUdon.SimplePlayerSettings
 
         public override void OnPlayerJoined(VRCPlayerApi player)
         {
+            // If the player is local, only set the properties that apply to them
             if (player.isLocal)
             {
                 player.SetWalkSpeed(walkSpeed);
@@ -192,14 +220,17 @@ namespace Varneon.VUdon.SimplePlayerSettings
                 player.SetAvatarEyeHeightMinimumByMeters(minimumHeight);
                 player.SetAvatarEyeHeightMaximumByMeters(maximumHeight);
             }
-            else
+            else if (overridePlayerVoices) // Player is remote and their voice properties should be overridden
             {
                 player.SetVoiceGain(voiceGain);
                 player.SetVoiceDistanceNear(voiceDistanceNear);
                 player.SetVoiceDistanceFar(voiceDistanceFar);
                 player.SetVoiceVolumetricRadius(voiceVolumetricRadius);
                 player.SetVoiceLowpass(voiceLowpass);
+            }
 
+            if (overrideAvatarAudio)
+            {
                 player.SetAvatarAudioGain(avatarAudioGain);
                 player.SetAvatarAudioNearRadius(avatarAudioNearRadius);
                 player.SetAvatarAudioFarRadius(avatarAudioFarRadius);


### PR DESCRIPTION
Fixes #2 

Inspector now includes toggles at the top of the audio foldouts, these can be used to conditionally disable overriding of the properties to ensure VRChat's default configuration will be used.

>[!IMPORTANT]
>Some users have reported problems with avatar audio in their worlds after implementing SimplePlayerSettings.
>This update should temporarily fix those issues while the default configuration's inaccuracies are being investigated

![Unity_54bzC6eKmY](https://github.com/user-attachments/assets/d47dca6f-82e2-4c36-b500-1863c081fc73)